### PR TITLE
Vertically center Window Buttons and App menu

### DIFF
--- a/unite@hardpixel.eu/stylesheet.css
+++ b/unite@hardpixel.eu/stylesheet.css
@@ -21,6 +21,7 @@
 }
 
 #panel .window-controls-box {
+  padding-bottom: 0.188em;
   spacing: 2px;
 }
 
@@ -45,4 +46,5 @@
 
 #panel #appMenu {
   margin: 0 8px;
+  padding-bottom: 0.063em;
 }


### PR DESCRIPTION
This commit improves the alignment of the left panel with the right panel, centering the options that were quoted in description.