### PR TITLE
Fixed moving window buttons in GNOME 3.38

### DIFF
--- a/unite@hardpixel.eu/panel.js
+++ b/unite@hardpixel.eu/panel.js
@@ -146,13 +146,15 @@ var WindowButtons = class WindowButtons extends PanelExtension {
 
   _onPositionChange() {
     const controls = this.controls.container
-
     if (controls.reparent) {
       controls.reparent(this.container)
     } else {
-      controls.unparent()
-      controls.set_parent(this.container)
-    }
+      const currentParent = controls.get_parent()
+      if (currentParent) {
+        currentParent.remove_child(controls)
+        this.container.add_child(controls)
+      }
+   }
 
     if (this.index != null) {
       this.container.set_child_at_index(controls, this.index)


### PR DESCRIPTION
Fixes #199 

`unparent()` and `reparent()` container methods removed from Shell, so to adjust we use window buttons container parent's methods directly.

WIP, I guess. I have not encountered any other errors but didn't check other possible deprecations. Feel free to comment if it needs any updates or just merge as-is.