### PR TITLE
Double-click the panel to unmaximize the top-most, maximized window.

### DIFF
--- a/unite@hardpixel.eu/panel.js
+++ b/unite@hardpixel.eu/panel.js
@@ -487,6 +487,70 @@ var TrayIcons = class TrayIcons extends PanelExtension {
   }
 }
 
+var PanelDoubleClick = GObject.registerClass(
+  class PanelDoubleClick extends GObject.Object {
+    _init() {
+    }
+
+    // double-clicking the top panel unmaximizes a window,
+    // (similiar to unmaximizing a window via DND from the top panel)
+    activate() {
+      this.doubleClickID = Main.panel.connect("button-press-event", (src, event) => {
+        if (event.get_button() !== 1 || event.get_click_count() !== 2)
+          return Clutter.EVENT_PROPAGATE;
+
+        const leftRect = {
+          x: Main.panel._leftBox.x,
+          y: Main.panel._leftBox.y,
+          width: Main.panel._leftBox.width,
+          height: Main.panel._leftBox.height
+        }
+        const centerRect = {
+          x: Main.panel._centerBox.x,
+          y: Main.panel._centerBox.y,
+          width: Main.panel._centerBox.width,
+          height: Main.panel._centerBox.height
+        }
+        const rightRect = {
+          x: Main.panel._rightBox.x,
+          y: Main.panel._rightBox.y,
+          width: Main.panel._rightBox.width,
+          height: Main.panel._rightBox.height
+        }
+
+        const mouseX = event.get_coords()[0];
+        const mouseY = event.get_coords()[1];
+
+        // don't unmaximize windows when quickly opening & closing menus
+        if (this.rectHasPoint(leftRect, mouseX, mouseY)
+            || this.rectHasPoint(centerRect, mouseX, mouseY)
+            || this.rectHasPoint(rightRect, mouseX, mouseY))
+          return Clutter.EVENT_PROPAGATE;
+
+        const maximizedWindow = Main.panel._getDraggableWindowForPosition(mouseX);
+
+        // assert maximizeFlags in case of some (tiling) extensions,
+        // which override Main.panel._getDraggableWindowForPosition()
+        // but don't use Meta.Window.maxmize()
+        const maximizeFlags = maximizedWindow?.get_maximized();
+        if (!maximizedWindow || !maximizeFlags)
+          return Clutter.EVENT_PROPAGATE;
+
+        maximizedWindow.unmaximize(maximizeFlags);
+        return Clutter.EVENT_STOP;
+      });
+    }
+
+    rectHasPoint(rect, pX, pY) {
+      return pX >= rect.x && pX <= rect.x + rect.width && pY >= rect.y && pY <= rect.y + rect.height;
+    }
+
+    destroy() {
+      Main.panel.disconnect(this.doubleClickID);
+    }
+  }
+)
+
 var PanelManager = GObject.registerClass(
   class UnitePanelManager extends GObject.Object {
     _init() {
@@ -496,6 +560,7 @@ var PanelManager = GObject.registerClass(
       this.activities = new ActivitiesButton(this)
       this.desktop    = new DesktopName(this)
       this.tray       = new TrayIcons(this)
+      this.dblClick   = new PanelDoubleClick()
     }
 
     activate() {
@@ -504,6 +569,7 @@ var PanelManager = GObject.registerClass(
       this.activities.activate()
       this.desktop.activate()
       this.tray.activate()
+      this.dblClick.activate()
     }
 
     destroy() {
@@ -512,6 +578,7 @@ var PanelManager = GObject.registerClass(
       this.activities.destroy()
       this.desktop.destroy()
       this.tray.destroy()
+      this.dblClick.destroy()
 
       this.settings.disconnectAll()
     }


### PR DESCRIPTION
Closes #89.

I used the `button-press-event` on the panel to implement this feature. But that would also unmaximize a window when quickly opening and closing a menu in the top panel. In the end I just checked, if the mouse click happened in the `Main.panel._leftBox`, `Main.panel._centerBox` or `Main.panel._rightBox`. Maybe there is a better way?

I tried to follow the convention from the implementation of the other features. But I didn't extend from PanelExtension since this feature is unrelated to a setting / is always-on. I just named the methods `activate` and `destroy`. Hope that's fine.

