### PR TITLE
Replace newlines with spaces for the appMenu app name/title.

### DIFF
--- a/unite@hardpixel.eu/window.js
+++ b/unite@hardpixel.eu/window.js
@@ -279,7 +279,8 @@ var MetaWindow = GObject.registerClass(
 
       if (label && this.hasFocus && this.title) {
         const current = label.get_text()
-        current != this.title && label.set_text(this.title)
+        const newText = this.title.replace(/\r?\n|\r/g, " ")
+        current != newText && label.set_text(newText)
       }
     }
 


### PR DESCRIPTION
Closes #212.
