### PR TITLE
Titlebar actions on top panel click

### DIFF
--- a/unite@hardpixel.eu/convenience.js
+++ b/unite@hardpixel.eu/convenience.js
@@ -25,6 +25,7 @@ var SettingsManager = GObject.registerClass(
         'show-window-buttons':        'enum',
         'window-buttons-theme':       'enum',
         'hide-window-titlebars':      'enum',
+        'enable-titlebar-actions':    'enum',
         'window-buttons-placement':   'select',
         'hide-dropdown-arrows':       'boolean',
         'hide-aggregate-menu-arrow':  'boolean',

--- a/unite@hardpixel.eu/convenience.js
+++ b/unite@hardpixel.eu/convenience.js
@@ -25,7 +25,7 @@ var SettingsManager = GObject.registerClass(
         'show-window-buttons':        'enum',
         'window-buttons-theme':       'enum',
         'hide-window-titlebars':      'enum',
-        'enable-titlebar-actions':    'enum',
+        'enable-titlebar-actions':    'boolean',
         'window-buttons-placement':   'select',
         'hide-dropdown-arrows':       'boolean',
         'hide-aggregate-menu-arrow':  'boolean',

--- a/unite@hardpixel.eu/panel.js
+++ b/unite@hardpixel.eu/panel.js
@@ -5,6 +5,7 @@ const GLib       = imports.gi.GLib
 const St         = imports.gi.St
 const Pango      = imports.gi.Pango
 const Clutter    = imports.gi.Clutter
+const Meta       = imports.gi.Meta
 const Shell      = imports.gi.Shell
 const AppSystem  = imports.gi.Shell.AppSystem.get_default()
 const WinTracker = imports.gi.Shell.WindowTracker.get_default()
@@ -539,6 +540,11 @@ var TitlebarActions = class TitlebarActions extends PanelExtension {
       action = this.settings.get('action-right-click-titlebar')
     }
 
+    if (action == 'menu') {
+      this._openWindowMenu(focusWindow.win, mouseX)
+      return Clutter.EVENT_STOP
+    }
+
     if (action && action != 'none') {
       return this._handleClickAction(action, focusWindow)
     }
@@ -564,6 +570,14 @@ var TitlebarActions = class TitlebarActions extends PanelExtension {
     }
 
     return Clutter.EVENT_PROPAGATE
+  }
+
+  _openWindowMenu(win, x) {
+    const size = Main.panel.height + 4
+    const rect = { x, y: 0, width: size, height: size }
+    const type = Meta.WindowMenuType.WM
+
+    Main.wm._windowMenuManager.showWindowMenuForWindow(win, type, rect)
   }
 
   _destroy() {

--- a/unite@hardpixel.eu/panel.js
+++ b/unite@hardpixel.eu/panel.js
@@ -492,7 +492,7 @@ var TrayIcons = class TrayIcons extends PanelExtension {
 
 var TitlebarActions = class TitlebarActions extends PanelExtension {
   constructor({ settings }) {
-    const active = val => val != 'never'
+    const active = val => val == true
     super(settings, 'enable-titlebar-actions', active)
   }
 
@@ -508,7 +508,7 @@ var TitlebarActions = class TitlebarActions extends PanelExtension {
   _onButtonPressEvent(actor, event) {
     const focusWindow = global.unite.focusWindow
 
-    if (!focusWindow || !focusWindow.enableActions) {
+    if (!focusWindow || !focusWindow.hideTitlebars) {
       return Clutter.EVENT_PROPAGATE
     }
 

--- a/unite@hardpixel.eu/schemas/org.gnome.shell.extensions.unite.gschema.xml
+++ b/unite@hardpixel.eu/schemas/org.gnome.shell.extensions.unite.gschema.xml
@@ -47,6 +47,14 @@
     <value value="4" nick="always" />
   </enum>
 
+  <enum id="org.gnome.shell.extensions.unite.titlebarActions">
+    <value value="0" nick="never" />
+    <value value="1" nick="tiled" />
+    <value value="2" nick="maximized" />
+    <value value="3" nick="both" />
+    <value value="4" nick="always" />
+  </enum>
+
   <enum id="org.gnome.shell.extensions.unite.notificationsPosition">
     <value value="0" nick="center" />
     <value value="1" nick="left" />
@@ -164,6 +172,11 @@
     <key name="hide-window-titlebars" enum="org.gnome.shell.extensions.unite.hideTitlebars">
       <default>"maximized"</default>
       <summary>Select windows state to hide titlebars.</summary>
+    </key>
+
+    <key name="enable-titlebar-actions" enum="org.gnome.shell.extensions.unite.titlebarActions">
+      <default>"maximized"</default>
+      <summary>Enable window titlebar actions on top bar click.</summary>
     </key>
 
     <key name="notifications-position" enum="org.gnome.shell.extensions.unite.notificationsPosition">

--- a/unite@hardpixel.eu/schemas/org.gnome.shell.extensions.unite.gschema.xml
+++ b/unite@hardpixel.eu/schemas/org.gnome.shell.extensions.unite.gschema.xml
@@ -47,14 +47,6 @@
     <value value="4" nick="always" />
   </enum>
 
-  <enum id="org.gnome.shell.extensions.unite.titlebarActions">
-    <value value="0" nick="never" />
-    <value value="1" nick="tiled" />
-    <value value="2" nick="maximized" />
-    <value value="3" nick="both" />
-    <value value="4" nick="always" />
-  </enum>
-
   <enum id="org.gnome.shell.extensions.unite.notificationsPosition">
     <value value="0" nick="center" />
     <value value="1" nick="left" />
@@ -107,6 +99,11 @@
     <key name="desktop-name-text" type="s">
       <default>"GNOME Desktop"</default>
       <summary>Set the top bar desktop name text.</summary>
+    </key>
+
+    <key name="enable-titlebar-actions" type="b">
+      <default>true</default>
+      <summary>Enable window titlebar actions on top bar click.</summary>
     </key>
 
     <key name="restrict-to-primary-screen" type="b">
@@ -172,11 +169,6 @@
     <key name="hide-window-titlebars" enum="org.gnome.shell.extensions.unite.hideTitlebars">
       <default>"maximized"</default>
       <summary>Select windows state to hide titlebars.</summary>
-    </key>
-
-    <key name="enable-titlebar-actions" enum="org.gnome.shell.extensions.unite.titlebarActions">
-      <default>"maximized"</default>
-      <summary>Enable window titlebar actions on top bar click.</summary>
     </key>
 
     <key name="notifications-position" enum="org.gnome.shell.extensions.unite.notificationsPosition">

--- a/unite@hardpixel.eu/settings.ui
+++ b/unite@hardpixel.eu/settings.ui
@@ -357,6 +357,52 @@
           </packing>
         </child>
         <child>
+          <object class="GtkBox" id="enable_titlebar_actions_section">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="spacing">50</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Enable titlebar actions on top bar click</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBoxText" id="enable_titlebar_actions">
+                <property name="width-request">170</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="active-id">2</property>
+                <items>
+                  <item id="0" translatable="yes">Never</item>
+                  <item id="1" translatable="yes">Tiled</item>
+                  <item id="2" translatable="yes">Maximized</item>
+                  <item id="3" translatable="yes">Both</item>
+                  <item id="4" translatable="yes">Always</item>
+                </items>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack-type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">8</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkBox" id="show_window_buttons_section">
             <property name="visible">True</property>
             <property name="can-focus">False</property>

--- a/unite@hardpixel.eu/settings.ui
+++ b/unite@hardpixel.eu/settings.ui
@@ -182,6 +182,45 @@
           </packing>
         </child>
         <child>
+          <object class="GtkBox" id="enable_titlebar_actions_section">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="spacing">50</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Enable titlebar actions on top bar click</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="enable_titlebar_actions">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="valign">center</property>
+                <property name="active">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack-type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkBox" id="restrict_to_primary_screen_section">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -217,7 +256,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">5</property>
           </packing>
         </child>
         <child>
@@ -261,7 +300,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">6</property>
           </packing>
         </child>
         <child>
@@ -307,7 +346,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">6</property>
+            <property name="position">7</property>
           </packing>
         </child>
         <child>
@@ -330,52 +369,6 @@
             </child>
             <child>
               <object class="GtkComboBoxText" id="show_window_title">
-                <property name="width-request">170</property>
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="active-id">2</property>
-                <items>
-                  <item id="0" translatable="yes">Never</item>
-                  <item id="1" translatable="yes">Tiled</item>
-                  <item id="2" translatable="yes">Maximized</item>
-                  <item id="3" translatable="yes">Both</item>
-                  <item id="4" translatable="yes">Always</item>
-                </items>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack-type">end</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">7</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="enable_titlebar_actions_section">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="spacing">50</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes">Enable titlebar actions on top bar click</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkComboBoxText" id="enable_titlebar_actions">
                 <property name="width-request">170</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>

--- a/unite@hardpixel.eu/window.js
+++ b/unite@hardpixel.eu/window.js
@@ -236,6 +236,10 @@ var MetaWindow = GObject.registerClass(
       return this._parseEnumSetting('hide-window-titlebars')
     }
 
+    get enableActions() {
+      return this._parseEnumSetting('enable-titlebar-actions')
+    }
+
     minimize() {
       if (this.minimized) {
         this.win.unminimize()

--- a/unite@hardpixel.eu/window.js
+++ b/unite@hardpixel.eu/window.js
@@ -256,6 +256,34 @@ var MetaWindow = GObject.registerClass(
       }
     }
 
+    maximizeX() {
+      if (this.win.maximized_horizontally) {
+        this.win.unmaximize(Meta.MaximizeFlags.HORIZONTAL)
+      } else {
+        this.win.maximize(Meta.MaximizeFlags.HORIZONTAL)
+      }
+    }
+
+    maximizeY() {
+      if (this.win.maximized_vertically) {
+        this.win.unmaximize(Meta.MaximizeFlags.VERTICAL)
+      } else {
+        this.win.maximize(Meta.MaximizeFlags.VERTICAL)
+      }
+    }
+
+    shade() {
+      if (this.win.is_shaded) {
+        this.win.shade(true)
+      } else {
+        this.win.unshade(true)
+      }
+    }
+
+    lower() {
+      this.win.lower()
+    }
+
     close() {
       const time = global.get_current_time()
       time && this.win.delete(time)

--- a/unite@hardpixel.eu/window.js
+++ b/unite@hardpixel.eu/window.js
@@ -236,10 +236,6 @@ var MetaWindow = GObject.registerClass(
       return this._parseEnumSetting('hide-window-titlebars')
     }
 
-    get enableActions() {
-      return this._parseEnumSetting('enable-titlebar-actions')
-    }
-
     minimize() {
       if (this.minimized) {
         this.win.unminimize()


### PR DESCRIPTION
This PR extends the functionality implemented in #221 by adding support for all actions set in GNOME Tweaks > Titlebar Actions.

Closes #60 