### PR TITLE
Do not attempt to disconnect from object if it is null

### DIFF
--- a/unite@hardpixel.eu/handlers.js
+++ b/unite@hardpixel.eu/handlers.js
@@ -105,7 +105,9 @@ var Signals = class Signals {
   disconnect(key) {
     if (this.hasSignal(key)) {
       const data = this.signals.get(key)
-      data.object.disconnect(data.signalId)
+      if (data.object != null) {
+        data.object.disconnect(data.signalId)
+      }
 
       this.signals.delete(key)
     }


### PR DESCRIPTION
Package: gnome-shell
Version: 3.36.9-0ubuntu0.20.04.2

  "url": "https://github.com/hardpixel/unite-shell",
  "uuid": "unite@hardpixel.eu",
  "version": 55

After resuming laptop the unite extension would no longer work, would need to ALT-F2 r to get icons back.

Here is the relevant portion of the journal:
```
Sep 25 21:19:07 postel gnome-shell[2899]: Object .Gjs_ui_dash_ShowAppsIcon (0x56323046f790), has been already deallocated — impossible to access it. This might be caused by the object having ben destroyed from C code using something such as destroy(), dispose(), or remove() vfuncs.
Sep 25 21:19:07 postel gnome-shell[2899]: == Stack trace for context 0x56322d2216a0 ==
Sep 25 21:19:07 postel gnome-shell[2899]: #0   7fff337af440 I   resource:///org/gnome/gjs/modules/core/overrides/GObject.js:571 (1005cefb6c40 @ 25)
Sep 25 21:19:07 postel gnome-shell[2899]: #1   7fff337af510 b   /home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/handlers.js:96 (22df30605c40 @ 91)
Sep 25 21:19:07 postel gnome-shell[2899]: #2   7fff337af5f0 b   /home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/handlers.js:108 (22df30605d30 @ 127)
Sep 25 21:19:07 postel gnome-shell[2899]: #3   56322d97d9f8 i   /home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/layout.js:145 (22df30614d30 @ 48)
Sep 25 21:19:07 postel gnome-shell[2899]: #4   56322d97d970 i   /home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/handlers.js:180 (22df3060b268 @ 37)
Sep 25 21:19:07 postel gnome-shell[2899]: #5   56322d97d8e8 i   /home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/handlers.js:191 (22df3060b448 @ 10)
Sep 25 21:19:07 postel gnome-shell[2899]: #6   7fff337b0440 I   self-hosted:266 (4220b738bc8 @ 259)
Sep 25 21:19:07 postel gnome-shell[2899]: #7   56322d97d850 i   /home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/handlers.js:191 (22df3060b3d0 @ 28)
Sep 25 21:19:07 postel gnome-shell[2899]: #8   56322d97d7c0 i   /home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/layout.js:216 (22df3061a268 @ 22)
Sep 25 21:19:07 postel gnome-shell[2899]: #9   56322d97d728 i   /home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/extension.js:30 (36b0614da9e8 @ 42)
Sep 25 21:19:07 postel gnome-shell[2899]: #10   56322d97d6a0 i   /home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/extension.js:44 (1eef4779f9e8 @ 17)
Sep 25 21:19:07 postel gnome-shell[2899]: #11   7fff337b13f0 b   resource:///org/gnome/shell/ui/extensionSystem.js:108 (4220b764880 @ 394)
Sep 25 21:19:07 postel gnome-shell[2899]: #12   56322d97d610 i   resource:///org/gnome/shell/ui/extensionSystem.js:626 (4220b76abc8 @ 15)
Sep 25 21:19:07 postel gnome-shell[2899]: #13   7fff337b2240 I   self-hosted:266 (4220b738bc8 @ 259)
Sep 25 21:19:07 postel gnome-shell[2899]: #14   56322d97d580 i   resource:///org/gnome/shell/ui/extensionSystem.js:625 (4220b76ab50 @ 98)
Sep 25 21:19:07 postel gnome-shell[2899]: #15   56322d97d4f0 i   resource:///org/gnome/shell/ui/extensionSystem.js:643 (4220b76ac40 @ 82)
Sep 25 21:19:07 postel gnome-shell[2899]: #16   7fff337b3100 b   self-hosted:1009 (2e61152a1d30 @ 423)
Sep 25 21:19:07 postel gnome-shell[2899]: #17   7fff337b3200 b   resource:///org/gnome/gjs/modules/core/_signals.js:133 (36b0614cb100 @ 427)
Sep 25 21:19:07 postel gnome-shell[2899]: #18   7fff337b3d20 b   resource:///org/gnome/shell/ui/sessionMode.js:198 (2e6115226e20 @ 286)
Sep 25 21:19:07 postel gnome-shell[2899]: #19   56322d97d390 i   resource:///org/gnome/shell/ui/sessionMode.js:159 (2e6115226c40 @ 40)
Sep 25 21:19:07 postel gnome-shell[2899]: #20   56322d97d2d8 i   resource:///org/gnome/shell/ui/screenShield.js:607 (2e6115213d30 @ 191)
Sep 25 21:19:07 postel gnome-shell[2899]: #21   56322d97d218 i   resource:///org/gnome/shell/ui/screenShield.js:656 (2e6115213da8 @ 419)
Sep 25 21:19:07 postel gnome-shell[2899]: #22   56322d97d180 i   resource:///org/gnome/shell/ui/screenShield.js:255 (2e611520ef88 @ 65)
Sep 25 21:19:07 postel gnome-shell[2899]: #23   7fff337b4920 b   self-hosted:1011 (2e61152a1d30 @ 454)
Sep 25 21:19:07 postel gnome-shell[2899]: #24   7fff337b4a20 b   resource:///org/gnome/gjs/modules/core/_signals.js:133 (36b0614cb100 @ 427)
Sep 25 21:19:07 postel gnome-shell[2899]: #25   56322d97d0c8 i   resource:///org/gnome/shell/misc/loginManager.js:198 (4220b706808 @ 202)
Sep 25 21:19:07 postel gnome-shell[2899]: #26   7fff337b5910 b   self-hosted:1013 (2e61152a1d30 @ 492)
Sep 25 21:19:07 postel gnome-shell[2899]: #27   7fff337b5a20 b   resource:///org/gnome/gjs/modules/core/_signals.js:133 (36b0614cb100 @ 427)
Sep 25 21:19:07 postel gnome-shell[2899]: #28   56322d97d018 i   resource:///org/gnome/gjs/modules/core/overrides/Gio.js:169 (1005cef92880 @ 39)
Sep 25 21:19:07 postel gnome-shell[2899]: JS ERROR: Extension unite@hardpixel.eu: Error: Argument 'instance' (type interface) may not be null
                                          _init/GObject.Object.prototype.disconnect@resource:///org/gnome/gjs/modules/core/overrides/GObject.js:571:24
                                          disconnect@/home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/handlers.js:96:19
                                          disconnectAll@/home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/handlers.js:108:12
                                          destroy@/home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/layout.js:145:18
                                          add/feature._doDestroy@/home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/handlers.js:180:17
                                          destroy/<@/home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/handlers.js:191:46
                                          destroy@/home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/handlers.js:191:19
                                          destroy@/home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/layout.js:216:21
                                          destroy@/home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/extension.js:30:26
                                          disable@/home/njsf/.local/share/gnome-shell/extensions/unite@hardpixel.eu/extension.js:44:16
                                          _callExtensionDisable@resource:///org/gnome/shell/ui/extensionSystem.js:108:32
                                          _disableAllExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:626:22
                                          _disableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:625:52
                                          _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:643:18
                                          _emit@resource:///org/gnome/gjs/modules/core/_signals.js:133:47
                                          _sync@resource:///org/gnome/shell/ui/sessionMode.js:198:14
                                          pushMode@resource:///org/gnome/shell/ui/sessionMode.js:159:14
                                          activate@resource:///org/gnome/shell/ui/screenShield.js:607:34
                                          lock@resource:///org/gnome/shell/ui/screenShield.js:656:14
                                          _prepareForSleep@resource:///org/gnome/shell/ui/screenShield.js:255:22
                                          _emit@resource:///org/gnome/gjs/modules/core/_signals.js:133:47
                                          _prepareForSleep@resource:///org/gnome/shell/misc/loginManager.js:198:14
                                          _emit@resource:///org/gnome/gjs/modules/core/_signals.js:133:47
                                          _convertToNativeSignal@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:169:19
```

The change below keeps the icons after suspend/resume and log entry no longer occurs