### PR TITLE
Leave space on top panel for windows' buttons

### DIFF
--- a/unite@hardpixel.eu/buttons.js
+++ b/unite@hardpixel.eu/buttons.js
@@ -126,7 +126,7 @@ var WindowControls = GObject.registerClass(
     }
 
     setVisible(visible) {
-      this.container.visible = visible
+      this._controls.visible = visible;
     }
   }
 )


### PR DESCRIPTION
Fixes #208.

Prevents system menu from moving, at the expense of leaving awkward empty space:

![image](https://user-images.githubusercontent.com/23058303/145608644-93e50ea3-5575-4c91-8ded-4c28d99e7b36.png)
