### PR TITLE
Add 42 since it works there too

### DIFF
--- a/unite@hardpixel.eu/metadata.json
+++ b/unite@hardpixel.eu/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.32", "3.34", "3.36", "3.38", "40", "41"],
+  "shell-version": ["3.32", "3.34", "3.36", "3.38", "40", "41", "42"],
   "uuid": "unite@hardpixel.eu",
   "url": "https://github.com/hardpixel/unite-shell",
   "settings-schema": "org.gnome.shell.extensions.unite",


### PR DESCRIPTION
Tested on Ubuntu Jammy Jellyfish + GNOME PPA with gnome-shell 42~alpha.

Preferences works too.

Thanks for this nice and useful extension.