### PR TITLE
Fix decoration issues on x11 on gnome-shell/mutter 44

### DIFF
--- a/unite@hardpixel.eu/window.js
+++ b/unite@hardpixel.eu/window.js
@@ -19,7 +19,7 @@ const VALID_TYPES = [
 const MOTIF_HINTS = '_MOTIF_WM_HINTS'
 
 const _SHOW_FLAGS = ['0x2', '0x0', '0x1', '0x0', '0x0']
-const _HIDE_FLAGS = ['0x2', '0x0', '0x2', '0x0', '0x0']
+const _HIDE_FLAGS = ['0x2', '0x0', '0x0', '0x0', '0x0']
 
 function isValid(win) {
   return win && VALID_TYPES.includes(win.window_type)
@@ -59,14 +59,15 @@ var ServerDecorations = class ServerDecorations {
   constructor({ xid, win }) {
     this.xid = xid
     this.win = win
+    this.hidden_by_us = false
   }
 
   get decorated() {
-    return this.win.get_frame_type() !== Meta.FrameType.BORDER
+    return this.win.decorated
   }
 
   get handle() {
-    return this.win.decorated
+    return this.hidden_by_us
   }
 
   show() {
@@ -76,7 +77,8 @@ var ServerDecorations = class ServerDecorations {
   }
 
   hide() {
-    if (this.handle && this.decorated) {
+    if (this.decorated) {
+      this.hidden_by_us = true
       setHint(this.xid, MOTIF_HINTS, _HIDE_FLAGS)
     }
   }


### PR DESCRIPTION
- Change _HIDE_FLAGS to use 0x0 in decorations fields of _MOTIF_WM_HINTS
- Change ServerDecorations.handle to use a boolean flag tracking whether the window decorations were previously hidden by united, because mutter now keeps `window->decorated` in sync with `window->mwm_decorated`
- Change ServerDecorations.decorated to use `this.win.decorated` since that flag is now kept up-to-date. Additionally, win.get_frame_type() now seems to never become Meta.FrameType.BORDER

Fixes #324 
