### PR TITLE
GNOME extensions upload action

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,31 @@
+name: Ego Upload
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  upload-extension:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set up Deno
+        uses: denolib/setup-deno@v2
+        with:
+          deno-version: 1.x
+
+      - name: Run Ego Upload
+        run: |
+          ZIP_FILE="path/to/your/extension.zip"
+          deno run \
+            --allow-env=EGO_USERNAME,EGO_PASSWORD \
+            --allow-net=extensions.gnome.org \
+            https://raw.githubusercontent.com/swsnr/ego-upload/main/ego-upload.ts \
+            $ZIP_FILE
+        env:
+          EGO_USERNAME: ${{ secrets.EGO_USERNAME }}
+          EGO_PASSWORD: ${{ secrets.EGO_PASSWORD }}


### PR DESCRIPTION
Solves https://github.com/hardpixel/unite-shell/issues/353

I haven't tested it

Steps to get working:
1. Navigate to https://github.com/hardpixel/unite-shell/settings/secrets/actions
2. Create repository secret `EGO_USERNAME` with username
3. Create repository secret `EGO_PASSWORD` with password

Resource: https://github.com/swsnr/ego-upload

This action will trigger on a gh release, but that can be changed. It will also use the code from the main branch.