### PR TITLE
Add gnome 48 to supported versions

### DIFF
--- a/unite@hardpixel.eu/metadata.json
+++ b/unite@hardpixel.eu/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["45", "46", "47"],
+  "shell-version": ["45", "46", "47", "48"],
   "uuid": "unite@hardpixel.eu",
   "url": "https://github.com/hardpixel/unite-shell",
   "settings-schema": "org.gnome.shell.extensions.unite",


### PR DESCRIPTION
fix #391 