### PR TITLE
appmenu: subclass animation spinner to avoid gnome shell crash

### DIFF
--- a/unite@hardpixel.eu/animation.js
+++ b/unite@hardpixel.eu/animation.js
@@ -1,0 +1,36 @@
+import GObject from 'gi://GObject'
+import St from 'gi://St'
+import Clutter from 'gi://Clutter'
+import * as Animation from 'resource:///org/gnome/shell/ui/animation.js'
+
+export const Spinner = GObject.registerClass(
+  class UniteSpinner extends Animation.Spinner {
+    play() {
+      if (!this._spinner) {
+        this._spinner = new St.SpinnerContent()
+        this.set_content(this._spinner)
+      }
+
+      this.remove_all_transitions()
+      this.show()
+
+      this.ease({
+        opacity: 255,
+        delay: 1000,
+        duration: 300,
+        mode: Clutter.AnimationMode.LINEAR
+      })
+    }
+
+    stop() {
+      this.remove_all_transitions()
+
+      this.ease({
+        opacity: 0,
+        duration: 300,
+        mode: Clutter.AnimationMode.LINEAR,
+        onComplete: () => { this.hide() }
+      })
+    }
+  }
+)

--- a/unite@hardpixel.eu/buttons.js
+++ b/unite@hardpixel.eu/buttons.js
@@ -4,7 +4,7 @@ import Clutter from 'gi://Clutter'
 import { AppMenu } from 'resource:///org/gnome/shell/ui/appMenu.js'
 import * as Main from 'resource:///org/gnome/shell/ui/main.js'
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js'
-import * as Animation from 'resource:///org/gnome/shell/ui/animation.js'
+import * as Animation from './animation.js'
 
 export const AppmenuLabel = GObject.registerClass(
   class UniteAppmenuLabel extends PanelMenu.Button {


### PR DESCRIPTION
Fix #394 