### PR TITLE
feat: add support for gnome 49

### DIFF
--- a/unite@hardpixel.eu/metadata.json
+++ b/unite@hardpixel.eu/metadata.json
@@ -1,10 +1,10 @@
 {
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["45", "46", "47", "48", "49"],
   "uuid": "unite@hardpixel.eu",
   "url": "https://github.com/hardpixel/unite-shell",
   "settings-schema": "org.gnome.shell.extensions.unite",
   "gettext-domain": "unite",
-  "version": 82,
+  "version": 83,
   "name": "Unite",
   "description": "Unite is a GNOME Shell extension which makes a few layout tweaks to the top panel and removes window decorations to make it look like the Unity Shell.\n\n- Adds window buttons to the top panel for maximized windows.\n- Shows current window title in the app menu for maximized windows.\n- Removes titlebars on maximized windows.\n- Hides window controls on maximized windows with headerbars.\n- Moves the date to the right, reduces panel spacing and removes dropdown arrows.\n- Moves legacy tray icons to the top panel.\n- Moves notifications to the right.\n- Hides workspace switcher button.\n- Adds desktop name to the top panel.\n\nThis extension depends on some Xorg utilities. To install them:\n- Debian/Ubuntu: apt install x11-utils\n- Fedora/RHEL: dnf install xprop\n- Arch and derivatives: pacman -S xorg-xprop\n\n*Settings are provided to enable/disable or customize the available tweaks.\n* Since version 2, applications on Wayland with client side decorations are supported using CSS.",
   "donations": {


### PR DESCRIPTION
## Summary
This change adds support for Gnome 49 - I've verified it on a system running Fedora 43 Pre-Release with Gnome 49 on Wayland!

## AI Disclaimer
> Generated by Gemini 2.5 using Crush
> 💘 Generated with Crush
> Co-Authored-By: Crush <crush@charm.land>